### PR TITLE
$transaction treated as stdClass instead of array

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $json = [
 ];
 
 $transaction = $client->transactions->create($json);
-header('Location: '. $transaction["url"]); // Go to transaction payment page
+header('Location: '. $transaction->url); // Go to transaction payment page
 ```
 
 #### Create transaction without a payment method that will redirect to the payment method selection screen
@@ -110,7 +110,7 @@ $json = [
 ];
 
 $transaction = $client->transactions->create($json);
-header('Location: '. $transaction["url"]); // Go to payment method selection screen
+header('Location: '. $transaction->url); // Go to payment method selection screen
 ```
 
 


### PR DESCRIPTION
Transactions::create returns an stdClass instead of an array